### PR TITLE
history: table skeleton and filler data

### DIFF
--- a/Frontend/app/history/page.tsx
+++ b/Frontend/app/history/page.tsx
@@ -7,15 +7,43 @@ import Head from 'next/head';
 import { useAccount } from "wagmi";
 import { useState, useEffect } from "react";
 
+import {
+    Table,
+    TableBody,
+    TableCaption,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+  } from "@/components/ui/table";  
+
+import {
+    SimpleTable, 
+    sampleInvoices,
+} from "@/components/simple-table";
 
 const History: NextPage = () => {
 
   const [isClient, setIsClient] = useState(false);
+  const [invoices, setInvoices] = useState(
+    sampleInvoices
+  );
 
   useEffect(() => {
     setIsClient(true);
   }, []);
 
+  const addInvoice = () => {
+    // Create a new invoice and add it to the invoices state
+    const newInvoice = {
+      invoice: `INV00${invoices.length + 1}`,
+      paymentStatus: 'Pending',
+      totalAmount: '$100.00',
+      paymentMethod: 'Credit Card',
+    };
+
+    setInvoices((prevInvoices) => [...prevInvoices, newInvoice]);
+  };
 
   return (
     <div>
@@ -29,9 +57,8 @@ const History: NextPage = () => {
       </Head>
 
       <main>
-
-        <h1>History</h1>
-        
+        <button onClick={addInvoice}>Add Invoice</button>
+        <SimpleTable invoices={invoices} />
       </main>
 
     </div>

--- a/Frontend/app/history/page.tsx
+++ b/Frontend/app/history/page.tsx
@@ -19,14 +19,15 @@ import {
 
 import {
     SimpleTable, 
-    sampleInvoices,
+    // sampleInvoices,
+    sampleResponses,
 } from "@/components/simple-table";
 
 const History: NextPage = () => {
 
   const [isClient, setIsClient] = useState(false);
-  const [invoices, setInvoices] = useState(
-    sampleInvoices
+  const [tableInput, setTableInput] = useState(
+    sampleResponses
   );
 
   useEffect(() => {
@@ -35,14 +36,14 @@ const History: NextPage = () => {
 
   const addInvoice = () => {
     // Create a new invoice and add it to the invoices state
-    const newInvoice = {
-      invoice: `INV00${invoices.length + 1}`,
-      paymentStatus: 'Pending',
-      totalAmount: '$100.00',
-      paymentMethod: 'Credit Card',
+    const newRow = {
+      model: `0x${tableInput.length + 1}`,
+      prompt: 'how do we move forward',
+      betterResponse: 'by looking backward',
+      worseResponse: 'by building more robots',
     };
 
-    setInvoices((prevInvoices) => [...prevInvoices, newInvoice]);
+    setTableInput((prevInvoices) => [...prevInvoices, newRow]);
   };
 
   return (
@@ -57,8 +58,8 @@ const History: NextPage = () => {
       </Head>
 
       <main>
-        <button onClick={addInvoice}>Add Invoice</button>
-        <SimpleTable invoices={invoices} />
+        <button onClick={addInvoice}>Add Row</button>
+        <SimpleTable tableInput={tableInput} />
       </main>
 
     </div>

--- a/Frontend/components/simple-table.tsx
+++ b/Frontend/components/simple-table.tsx
@@ -1,0 +1,82 @@
+import {
+    Table,
+    TableBody,
+    TableCaption,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+  } from "@/components/ui/table"
+  
+  export const sampleInvoices = [
+    {
+      invoice: "INV001",
+      paymentStatus: "Paid",
+      totalAmount: "$250.00",
+      paymentMethod: "Credit Card",
+    },
+    {
+      invoice: "INV002",
+      paymentStatus: "Pending",
+      totalAmount: "$150.00",
+      paymentMethod: "PayPal",
+    },
+    {
+      invoice: "INV003",
+      paymentStatus: "Unpaid",
+      totalAmount: "$350.00",
+      paymentMethod: "Bank Transfer",
+    },
+    {
+      invoice: "INV004",
+      paymentStatus: "Paid",
+      totalAmount: "$450.00",
+      paymentMethod: "Credit Card",
+    },
+    {
+      invoice: "INV005",
+      paymentStatus: "Paid",
+      totalAmount: "$550.00",
+      paymentMethod: "PayPal",
+    },
+    {
+      invoice: "INV006",
+      paymentStatus: "Pending",
+      totalAmount: "$200.00",
+      paymentMethod: "Bank Transfer",
+    },
+    {
+      invoice: "INV007",
+      paymentStatus: "Unpaid",
+      totalAmount: "$300.00",
+      paymentMethod: "Credit Card",
+    },
+  ]
+  
+  // TODO: once we have settled on the data interface, we can utilize the graph-client types here
+  export function SimpleTable({ invoices }) {
+    return (
+      <Table>
+        <TableCaption>A list of your recent invoices.</TableCaption>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="w-[100px]">Invoice</TableHead>
+            <TableHead>Status</TableHead>
+            <TableHead>Method</TableHead>
+            <TableHead className="text-right">Amount</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {invoices.map((invoice) => (
+            <TableRow key={invoice.invoice}>
+              <TableCell className="font-medium">{invoice.invoice}</TableCell>
+              <TableCell>{invoice.paymentStatus}</TableCell>
+              <TableCell>{invoice.paymentMethod}</TableCell>
+              <TableCell className="text-right">{invoice.totalAmount}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    )
+  }
+  

--- a/Frontend/components/simple-table.tsx
+++ b/Frontend/components/simple-table.tsx
@@ -8,6 +8,54 @@ import {
     TableRow,
   } from "@/components/ui/table"
   
+  export const sampleResponses = [
+    {
+      model: "0x1",
+      prompt: "hello, world",
+      betterResponse: "hello, world, its great to be here!",
+      worseResponse: "i have risen and will destroy you all",
+    },
+    {
+      model: "0x2",
+      prompt: "what is the meaning of life?",
+      betterResponse: "time cube knows all",
+      worseResponse: "to stack gwei",
+    },
+    {
+      model: "0x3",
+      prompt: "whats new york like in the summer?",
+      betterResponse: "sunnier than in the winter",
+      worseResponse: "smells like subway rates",
+    },
+  ]
+
+  export function SimpleTable({ tableInput }) {
+    return (
+        <Table>
+            <TableCaption>A list of prompts and responses for the models.</TableCaption>
+            <TableHeader>
+                <TableRow>
+                <TableHead className="w-[100px]">Model</TableHead>
+                <TableHead>Prompt</TableHead>
+                <TableHead>Better Response</TableHead>
+                <TableHead>Worse Response</TableHead>
+                </TableRow>
+            </TableHeader>
+            <TableBody>
+                {tableInput.map((row) => (
+                <TableRow key={row.model}>
+                    <TableCell className="font-medium">{row.model}</TableCell>
+                    <TableCell>{row.prompt}</TableCell>
+                    <TableCell>{row.betterResponse}</TableCell>
+                    <TableCell>{row.worseResponse}</TableCell>
+                </TableRow>
+                ))}
+            </TableBody>
+        </Table>
+    )
+}
+
+  /**
   export const sampleInvoices = [
     {
       invoice: "INV001",
@@ -52,7 +100,9 @@ import {
       paymentMethod: "Credit Card",
     },
   ]
+   */
   
+  /**
   // TODO: once we have settled on the data interface, we can utilize the graph-client types here
   export function SimpleTable({ invoices }) {
     return (
@@ -79,4 +129,13 @@ import {
       </Table>
     )
   }
+  */
   
+
+  /**
+
+   * 
+
+   * 
+   * 
+   */


### PR DESCRIPTION
Current:
- adds a simple table from `shadcn`
- adds filler data for the moment
- temporary `add data` button to test re-render 

Next: 
- [ ] integrate `graphclient` to handle `graphql` queries
- [ ] update `components/simple-table.tsx` to handle data returned from subgraph 
- [ ] modify `history/page.tsx` to query on initialization and render table

Optional: 
- [ ] filters: allow the user to filter the data as follows: (i believe the easiest way to do this would not to be to filter at the table level, but rather to filter at the query level, less performant, but simpler components)
    - [ ] by model 
    - [ ] by end user 
- [ ] optional: poller to routinely fetch most up to data data 